### PR TITLE
fix: deselect correct cell when resignFirstResponder

### DIFF
--- a/PickerCellDemo/DateInputTableViewCell.m
+++ b/PickerCellDemo/DateInputTableViewCell.m
@@ -118,7 +118,7 @@
 		// Nothing to do
 	}
 	UITableView *tableView = (UITableView *)self.superview;
-	[tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:YES];
+	[tableView deselectRowAtIndexPath:[tableView indexPathForCell:self] animated:YES];
 	return [super resignFirstResponder];
 }
 
@@ -196,7 +196,7 @@
 - (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
 	if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
 		UITableView *tableView = (UITableView *)self.superview;
-		[tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:YES];
+		[tableView deselectRowAtIndexPath:[tableView indexPathForCell:self] animated:YES];
 		[self resignFirstResponder];
 	}
 }

--- a/PickerCellDemo/IntegerInputTableViewCell.m
+++ b/PickerCellDemo/IntegerInputTableViewCell.m
@@ -94,7 +94,7 @@
 		[delegate tableViewCell:self didEndEditingWithInteger:self.numberValue];
 	}
 	UITableView *tableView = (UITableView *)self.superview;
-	[tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:YES];
+	[tableView deselectRowAtIndexPath:[tableView indexPathForCell:self] animated:YES];
 	return [super resignFirstResponder];
 }
 

--- a/PickerCellDemo/PickerInputTableViewCell.m
+++ b/PickerCellDemo/PickerInputTableViewCell.m
@@ -106,7 +106,7 @@
 		// Nothing to do
 	}
 	UITableView *tableView = (UITableView *)self.superview;
-	[tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:YES];
+	[tableView deselectRowAtIndexPath:[tableView indexPathForCell:self] animated:YES];
 	return [super resignFirstResponder];
 }
 
@@ -150,7 +150,7 @@
 
 - (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
 	UITableView *tableView = (UITableView *)self.superview;
-	[tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:YES];
+	[tableView deselectRowAtIndexPath:[tableView indexPathForCell:self] animated:YES];
 	[self resignFirstResponder];
 }
 

--- a/PickerCellDemo/StringInputTableViewCell.m
+++ b/PickerCellDemo/StringInputTableViewCell.m
@@ -81,7 +81,7 @@
 		[delegate tableViewCell:self didEndEditingWithString:self.stringValue];
 	}
 	UITableView *tableView = (UITableView *)self.superview;
-	[tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:YES];
+	[tableView deselectRowAtIndexPath:[tableView indexPathForCell:self] animated:YES];
 }
 
 - (void)layoutSubviews {


### PR DESCRIPTION
The previous code was deselecting the tableView selected cell
With the previous code, in case you touch cell B
when cell A was selected, cell B become the selected cell
and cell A resignFirstResponder is called
and deselect cell B (it should only deselect itself)
