### PR TITLE
Fix problem: when changing the date, it scrolls back to 'Today' automatically

### DIFF
--- a/PickerCellDemo/DateInputTableViewCell.m
+++ b/PickerCellDemo/DateInputTableViewCell.m
@@ -217,9 +217,10 @@
 }
 
 - (void)setTimerValue:(NSTimeInterval)timerValue {
-    datePicker.countDownDuration = timerValue;
-    _timerValue = timerValue;
     if (self.datePicker.datePickerMode == UIDatePickerModeCountDownTimer) {
+		datePicker.countDownDuration = timerValue;
+		_timerValue = timerValue;
+
         self.detailTextLabel.text = [self timerStringValue];
     } else {
         // self.detailTextLabel.text = [self.dateFormatter stringFromDate:self.dateValue];


### PR DESCRIPTION
...UIDatePickerModeCountDownTimer to fix the following problem: when changing date(in UIDatePickerModeDate or UIDatePickerModelDateAndTime mode) the UIDatePicker scrolls back to "Today" automatically.
