### PR TITLE
Fix for ipad resigning first responder of other table cells when first responder might be a subview of another table cell

### DIFF
--- a/PickerCellDemo/PickerInputTableViewCell.m
+++ b/PickerCellDemo/PickerInputTableViewCell.m
@@ -88,11 +88,7 @@
 		popoverController.popoverContentSize = pickerSize;
 		[popoverController presentPopoverFromRect:self.detailTextLabel.frame inView:self permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
 		// resign the current first responder
-		for (UIView *subview in self.superview.subviews) {
-			if ([subview isFirstResponder]) {
-				[subview resignFirstResponder];
-			}
-		}
+		[self.superview endEditing:YES];
 		return NO;
 	} else {
 		[self.picker setNeedsLayout];


### PR DESCRIPTION
Assuming the parent view is a UITableView (safe assumption) this is a
better way of resigning first responder that will also work with sister
table cells with subviews that are first responder (UIText View as a
subview, etc.)
